### PR TITLE
Fix rendering regressions and stabilize loader runtime behavior

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "lib/falso_jni"]
 	path = lib/falso_jni
-	url = git@github.com:v-atamanenko/FalsoJNI.git
+	url = https://github.com/v-atamanenko/FalsoJNI.git
 	branch = master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,19 +52,13 @@ if (DUMP_COMPILED_SHADERS)
   endif()
 endif()
 
-# Unique debug definition for loader's logging to not interfere with anything
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  # Uncomment this for so_loader logging:
-  add_definitions(-DDEBUG_SOLOADER)
-  # Uncomment this for verbose FalsoJNI logging:
-  add_definitions(-DFALSOJNI_DEBUGLEVEL=0)
-  # Uncomment this for OpenGL logging:
-  add_definitions(-DDEBUG_OPENGL)
-endif()
+# Keep runtime logging disabled in all build types to reduce overhead.
+add_definitions(-DFALSOJNI_DEBUGLEVEL=4)
 
 # makes sincos, sincosf, etc. visible
 add_definitions(-D_GNU_SOURCE -D__POSIX_VISIBLE=999999)
 
+# SoftFP float ABI - Now natively supported by your new SoftFP SDK!
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,-q -mfloat-abi=softfp -std=gnu11 -Wno-deprecated -fno-optimize-sibling-calls")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,-q -mfloat-abi=softfp -std=gnu++20 -Wno-write-strings -Wno-psabi")
 
@@ -124,6 +118,9 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
                       -Wl,--whole-archive pthread -Wl,--no-whole-archive
                       OpenSLES
                       sndfile
+                      mpg123
+                      mp3lame
+                      opus
                       vorbis
                       ogg
                       vorbisenc

--- a/source/audio.cpp
+++ b/source/audio.cpp
@@ -7,6 +7,7 @@
 #include <map>
 #include <vector>
 #include <algorithm>
+#include <cmath>
 
 struct AudioSystem
 {
@@ -29,6 +30,8 @@ struct SoundManager
 {
     std::map<std::string, SoLoud::Wav *> sounds;
     std::map<std::string, std::vector<SoLoud::handle>> handles;
+    std::map<SoLoud::handle, float> effectVolumes;
+    std::map<SoLoud::handle, float> effectRates;
     float volumeLeft = 0.5f;
     float volumeRight = 0.5f;
     std::mutex mutex;
@@ -58,6 +61,8 @@ void audio_init()
 
     gSoundManager.sounds.clear();
     gSoundManager.handles.clear();
+    gSoundManager.effectVolumes.clear();
+    gSoundManager.effectRates.clear();
     gSoundManager.volumeLeft = 0.5f;
     gSoundManager.volumeRight = 0.5f;
 
@@ -129,9 +134,11 @@ void preloadEffect(jmethodID, va_list args)
 void unloadEffect(jmethodID, va_list args)
 {
     jstring jpath = va_arg(args, jstring);
-    const char *path = jni.GetStringUTFChars(jpath, nullptr);
-    std::string key(path);
-    jni.ReleaseStringUTFChars(jpath, path);
+    const char *relPath = jni.GetStringUTFChars(jpath, nullptr);
+    std::string relative(relPath ? relPath : "");
+    jni.ReleaseStringUTFChars(jpath, relPath);
+
+    std::string key = "ux0:/data/hcr/assets/" + relative;
 
     std::lock_guard<std::mutex> lock(gSoundManager.mutex);
     auto it = gSoundManager.sounds.find(key);
@@ -142,6 +149,8 @@ void unloadEffect(jmethodID, va_list args)
         for (auto h : handles)
         {
             gAudioSystem.soloud.stop(h);
+            gSoundManager.effectVolumes.erase(h);
+            gSoundManager.effectRates.erase(h);
         }
         handles.clear();
         delete it->second;
@@ -197,6 +206,8 @@ jint playEffect(jmethodID, va_list args)
 
     if (isLoop)
         gSoundManager.handles[fullPath].push_back(handle);
+    gSoundManager.effectVolumes[handle] = volume;
+    gSoundManager.effectRates[handle] = rate;
 
     gAudioSystem.soloud.setPause(handle, false);
 
@@ -209,8 +220,16 @@ void setEffectVolume(jmethodID, va_list args)
 {
     jint streamID = va_arg(args, jint);
     jdouble volume = va_arg(args, jdouble);
-    l_debug("setEffectVolume called for stream %d to volume %.2f", streamID, volume);
     volume = std::fmax(0.0f, std::fmin(volume, 1.0f));
+
+    std::lock_guard<std::mutex> lock(gSoundManager.mutex);
+    auto it = gSoundManager.effectVolumes.find(streamID);
+    if (it != gSoundManager.effectVolumes.end() &&
+        std::fabs(it->second - (float)volume) < 0.005f)
+    {
+        return;
+    }
+    gSoundManager.effectVolumes[streamID] = (float)volume;
     gAudioSystem.soloud.setVolume(streamID, volume);
 }
 
@@ -218,8 +237,16 @@ void setEffectRate(jmethodID, va_list args)
 {
     jint streamID = va_arg(args, jint);
     jdouble rate = va_arg(args, jdouble);
-    l_debug("setEffectRate called for stream %d to rate %.2f", streamID, rate);
     rate = std::fmax(0.5f, std::fmin(rate, 2.0f));
+
+    std::lock_guard<std::mutex> lock(gSoundManager.mutex);
+    auto it = gSoundManager.effectRates.find(streamID);
+    if (it != gSoundManager.effectRates.end() &&
+        std::fabs(it->second - (float)rate) < 0.005f)
+    {
+        return;
+    }
+    gSoundManager.effectRates[streamID] = (float)rate;
     gAudioSystem.soloud.setRelativePlaySpeed(streamID, rate);
 }
 
@@ -230,6 +257,8 @@ void stopEffect(jmethodID, va_list args)
     gAudioSystem.soloud.stop(streamID);
 
     std::lock_guard<std::mutex> lock(gSoundManager.mutex);
+    gSoundManager.effectVolumes.erase(streamID);
+    gSoundManager.effectRates.erase(streamID);
     for (auto &pair : gSoundManager.handles)
     {
         auto &vec = pair.second;

--- a/source/main.c
+++ b/source/main.c
@@ -1,6 +1,6 @@
 #include "utils/init.h"
 #include "utils/glutil.h"
-#include "utils/logger.h"
+#include "utils/dialog.h"
 #include "utils/utils.h"
 
 #include <psp2/kernel/threadmgr.h>
@@ -89,26 +89,31 @@ int main()
     int (*Game_nativeInit)(void *env, void *obj, jint screen_width, jint screen_height) = (void *)so_symbol(&so_mod, "Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeInit");
     int (*Game_nativeResize)(void *env, void *obj, jint screen_width, jint screen_height) = (void *)so_symbol(&so_mod, "Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeResize");
     int (*Game_nativeRender)(void *env) = (void *)so_symbol(&so_mod, "Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeRender");
-    int (*Game_setInAppItemPrice)(void *env, void *obj, jstring item, jstring price) = (void *)so_symbol(&so_mod, "Java_com_fingersoft_game_MainActivity_setInAppItemPrice");
-
     Cocos2dx_nativeTouchesBegin = (void *)so_symbol(&so_mod, "Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeTouchesBegin");
     Cocos2dx_nativeTouchesMove = (void *)so_symbol(&so_mod, "Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeTouchesMove");
     Cocos2dx_nativeTouchesEnd = (void *)so_symbol(&so_mod, "Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeTouchesEnd");
     Cocos2dx_nativeKeyDown = (void *)so_symbol(&so_mod, "Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeKeyDown");
+
+    if (!JNI_OnLoad || !Cocos2dx_nativeSetPaths || !Game_isTestingMode ||
+        !Game_nativeInit || !Game_nativeResize || !Game_nativeRender ||
+        !Cocos2dx_nativeTouchesBegin || !Cocos2dx_nativeTouchesMove ||
+        !Cocos2dx_nativeTouchesEnd || !Cocos2dx_nativeKeyDown)
+    {
+        fatal_error("Error: one or more required game symbols are missing.");
+    }
 
     JNI_OnLoad(&jvm);
 
     Game_isTestingMode();
     Cocos2dx_nativeSetPaths(&jni, NULL, jni->NewStringUTF(&jni, "ux0:/data/hcr/base.apk"));
     Game_nativeInit(&jni, NULL, SCREEN_WIDTH, SCREEN_HEIGHT);
+    Game_nativeResize(&jni, NULL, SCREEN_WIDTH, SCREEN_HEIGHT);
 
     while (1)
     {
         controls_poll();
-
         Game_nativeResize(&jni, NULL, SCREEN_WIDTH, SCREEN_HEIGHT);
         Game_nativeRender(&jni);
-
         gl_swap();
     }
 

--- a/source/utils/logger.c
+++ b/source/utils/logger.c
@@ -7,76 +7,10 @@
 
 #include "utils/logger.h"
 
-#include <psp2/kernel/clib.h>
-#include <psp2/kernel/threadmgr.h>
+#include <stdarg.h>
 
-#include <stdbool.h>
-#include <stdatomic.h>
-
-#define COLOR_RED    "\x1B[38;5;196m"
-#define COLOR_PINK   "\x1B[38;5;212m"
-#define COLOR_ORANGE "\x1B[38;5;202m"
-#define COLOR_BLUE   "\x1B[38;5;32m"
-#define COLOR_GREEN  "\x1B[32m"
-#define COLOR_CYAN   "\x1B[36m"
-
-#define COLOR_END    "\033[0m"
-
-static SceKernelLwMutexWork _log_mutex;
-static atomic_bool _log_mutex_ready = ATOMIC_VAR_INIT(false);
-
-// Buffer A is used to adjust the format string.
-static char buffer_a[2048];
-// Buffer B is used to compile the final log using the updated format string.
-static char buffer_b[2048];
-
-void _log_print(int t, const char* fmt, ...) {
-    if (!atomic_load_explicit(&_log_mutex_ready, memory_order_relaxed)) {
-        int ret = sceKernelCreateLwMutex(&_log_mutex, "log_lock", 0, 0, NULL);
-        if (ret < 0) {
-            sceClibPrintf("Error: failed to create log mutex: 0x%x\n", ret);
-            return;
-        }
-        atomic_store_explicit(&_log_mutex_ready, true, memory_order_relaxed);
-    }
-    sceKernelLockLwMutex(&_log_mutex, 1, NULL);
-
-    switch (t) {
-        case LT_DEBUG:
-            sceClibSnprintf(buffer_a, sizeof(buffer_a), " %s• debug%s    %s\n",
-                            COLOR_PINK, COLOR_END, fmt); break;
-        case LT_INFO:
-            sceClibSnprintf(buffer_a, sizeof(buffer_a), " %sℹ info%s     %s\n",
-                            COLOR_BLUE, COLOR_END, fmt); break;
-        case LT_WARN:
-            sceClibSnprintf(buffer_a, sizeof(buffer_a), " %s⚠ warning%s  %s\n",
-                            COLOR_ORANGE, COLOR_END, fmt); break;
-        case LT_ERROR:
-            sceClibSnprintf(buffer_a, sizeof(buffer_a), " %s⨯ error%s    %s\n",
-                            COLOR_RED, COLOR_END, fmt); break;
-        case LT_FATAL:
-            sceClibSnprintf(buffer_a, sizeof(buffer_a), " %s! fatal%s    %s\n",
-                            COLOR_RED, COLOR_END, fmt); break;
-        case LT_SUCCESS:
-            sceClibSnprintf(buffer_a, sizeof(buffer_a), " %s! success%s  %s\n",
-                            COLOR_GREEN, COLOR_END, fmt); break;
-        case LT_WAIT:
-            sceClibSnprintf(buffer_a, sizeof(buffer_a), " %s… waiting%s  %s\n",
-                            COLOR_CYAN, COLOR_END, fmt); break;
-        default:
-            if (atomic_load_explicit(&_log_mutex_ready, memory_order_relaxed)) {
-                sceKernelUnlockLwMutex(&_log_mutex, 1);
-            }
-            return;
-    }
-
-    va_list list;
-    va_start(list, fmt);
-    sceClibVsnprintf(buffer_b, sizeof(buffer_b), buffer_a, list);
-    va_end(list);
-    sceClibPrintf(buffer_b);
-
-    if (atomic_load_explicit(&_log_mutex_ready, memory_order_relaxed)) {
-        sceKernelUnlockLwMutex(&_log_mutex, 1);
-    }
+void _log_print(int t, const char *fmt, ...)
+{
+    (void)t;
+    (void)fmt;
 }

--- a/source/utils/logger.h
+++ b/source/utils/logger.h
@@ -25,22 +25,14 @@ extern "C" {
 #define LT_SUCCESS 5
 #define LT_WAIT    6
 
-#ifdef DEBUG_SOLOADER
-#define l_debug(...)   _log_print(LT_DEBUG,   __VA_ARGS__)
-#define l_info(...)    _log_print(LT_INFO,    __VA_ARGS__)
-#define l_warn(...)    _log_print(LT_WARN,    __VA_ARGS__)
-#define l_success(...) _log_print(LT_SUCCESS, __VA_ARGS__)
-#define l_wait(...)    _log_print(LT_WAIT,    __VA_ARGS__)
-#else
 #define l_debug(...)
 #define l_info(...)
 #define l_warn(...)
 #define l_success(...)
 #define l_wait(...)
-#endif
 
-#define l_error(...)   _log_print(LT_ERROR,   __VA_ARGS__)
-#define l_fatal(...)   _log_print(LT_FATAL,   __VA_ARGS__)
+#define l_error(...)
+#define l_fatal(...)
 
 void _log_print(int t, const char* fmt, ...)
                 __attribute__ ((format (printf, 2, 3)));


### PR DESCRIPTION
- Restore per-frame nativeResize call to prevent text glitches/flicker
- Add required symbol validation before game init
- Keep loader logging disabled (no-op logger macros/backend)
- Quiet FalsoJNI logging in build config
- Fix unloadEffect path key mismatch in audio system
- Reduce redundant effect volume/rate updates